### PR TITLE
Added Save/Save As support to Datasource

### DIFF
--- a/Document API/tableaudocumentapi/datasource.py
+++ b/Document API/tableaudocumentapi/datasource.py
@@ -18,12 +18,14 @@ class Datasource(object):
     # Public API.
     #
     ###########################################################################
-    def __init__(self, dsxml):
+    def __init__(self, dsxml, filename=None):
         """
         Constructor.  Default is to create datasource from xml.
 
         """
+        self._filename = filename
         self._datasourceXML = dsxml
+        self._datasourceTree = ET.ElementTree(self._datasourceXML)
         self._name = self._datasourceXML.get('name') or self._datasourceXML.get('formatted-name') # TDS files don't have a name attribute
         self._version = self._datasourceXML.get('version')
         self._connection = Connection(self._datasourceXML.find('connection'))
@@ -32,7 +34,36 @@ class Datasource(object):
     def from_file(cls, filename):
         "Initialize datasource from file (.tds)"
         dsxml = ET.parse(filename).getroot()
-        return cls(dsxml)
+        return cls(dsxml, filename)
+
+    def save(self):
+        """
+        Call finalization code and save file.
+
+        Args:
+            None.
+
+        Returns:
+            Nothing.
+
+        """
+
+        # save the file
+        self._datasourceTree.write(self._filename)
+
+    def save_as(self, new_filename):
+        """
+        Save our file with the name provided.
+
+        Args:
+            new_filename:  New name for the workbook file. String.
+
+        Returns:
+            Nothing.
+
+        """
+        self._datasourceTree.write(new_filename)
+
 
     ###########
     # name

--- a/Document API/tableaudocumentapi/workbook.py
+++ b/Document API/tableaudocumentapi/workbook.py
@@ -90,13 +90,8 @@ class Workbook(object):
 
         """
 
-        # We have a valid type of input file
-        if self._is_valid_file(new_filename):
-            # save the file
-            self._workbookTree.write(new_filename)
-        else:
-            print('Invalid file type. Must be .twb or .tds.')
-            raise Exception()
+        self._workbookTree.write(new_filename)
+
 
     ###########################################################################
     #

--- a/Document API/test.py
+++ b/Document API/test.py
@@ -78,6 +78,14 @@ class DatasourceModelTests(unittest.TestCase):
         ds = Datasource.from_file(self.tds_file.name)
         self.assertIsInstance(ds.connection, Connection)
 
+    def test_can_save_tds(self):
+        original_tds = Datasource.from_file(self.tds_file.name)
+        original_tds.connection.dbname = 'newdb.test.tsi.lan'
+        original_tds.save()
+
+        new_tds = Datasource.from_file(self.tds_file.name)
+        self.assertEqual(new_tds.connection.dbname, 'newdb.test.tsi.lan')
+
 
 class WorkbookModelTests(unittest.TestCase):
 


### PR DESCRIPTION
This required plumbing a filename through from the from_file classmethod and building an ElementTree to serialize into a file. This pretty much mirrors the Workbook model. I also removed the file validation check on save since we validate on instantiation already, at this point you know you have a 'twb/tds' open. Added a matching test.

Testing: Existing suite (up to 9!) on py2/3 on Windows/Mac. 
Also opened the resulting file in Desktop and it's recognized.
