### PR TITLE
Implemented ConnectionParser to handle Federated and Legacy connections

### DIFF
--- a/tableaudocumentapi/__init__.py
+++ b/tableaudocumentapi/__init__.py
@@ -1,5 +1,5 @@
 __version__ = '0.0.1'
 __VERSION__ = __version__
 from .connection import Connection
-from .datasource import Datasource
+from .datasource import Datasource, ConnectionParser
 from .workbook import Workbook

--- a/tableaudocumentapi/datasource.py
+++ b/tableaudocumentapi/datasource.py
@@ -12,18 +12,18 @@ class ConnectionParser(object):
         self._dsxml = datasource_xml
         self._dsversion = version
 
+    def _extract_federated_connections(self):
+        return list(map(Connection,self._dsxml.findall('.//named-connections/named-connection/*')))
+
+    def _extract_legacy_connection(self):
+        return Connection(self._dsxml.find('connection'))
+
     def get_connections(self):
         if float(self._dsversion) < 10:
             connections = self._extract_legacy_connection()
         else:
             connections = self._extract_federated_connections()
         return connections
-
-    def _extract_federated_connections(self):
-        return list(map(Connection,self._dsxml.findall('.//named-connections/named-connection/*')))
-
-    def _extract_legacy_connection(self):
-        return Connection(self._dsxml.find('connection'))
 
 
 class Datasource(object):

--- a/test.py
+++ b/test.py
@@ -3,29 +3,19 @@ import io
 import os
 import xml.etree.ElementTree as ET
 
-from tableaudocumentapi import Workbook, Datasource, Connection
+from tableaudocumentapi import Workbook, Datasource, Connection, ConnectionParser
 
-TABLEAU_93_WORKBOOK = '''<?xml version='1.0' encoding='utf-8' ?>
-<workbook source-build='9.3.1 (9300.16.0510.0100)' source-platform='mac' version='9.3' xmlns:user='http://www.tableausoftware.com/xml/user'>
-  <datasources>
-    <datasource caption='xy (TestV1)' inline='true' name='sqlserver.17u3bqc16tjtxn14e2hxh19tyvpo' version='9.3'>
-      <connection authentication='sspi' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username=''>
-      </connection>
-    </datasource>
-  </datasources>
-</workbook>'''
 
-TABLEAU_93_TDS = '''<?xml version='1.0' encoding='utf-8' ?>
-<datasource formatted-name='sqlserver.17u3bqc16tjtxn14e2hxh19tyvpo' inline='true' source-platform='mac' version='9.3' xmlns:user='http://www.tableausoftware.com/xml/user'>
-  <connection authentication='sspi' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username=''>
-  </connection>
-</datasource>'''
+TABLEAU_93_WORKBOOK = '''<?xml version='1.0' encoding='utf-8' ?><workbook source-build='9.3.1 (9300.16.0510.0100)' source-platform='mac' version='9.3' xmlns:user='http://www.tableausoftware.com/xml/user'><datasources><datasource caption='xy (TestV1)' inline='true' name='sqlserver.17u3bqc16tjtxn14e2hxh19tyvpo' version='9.3'><connection authentication='sspi' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username=''></connection></datasource></datasources></workbook>'''
+
+TABLEAU_93_TDS = '''<?xml version='1.0' encoding='utf-8' ?><datasource formatted-name='sqlserver.17u3bqc16tjtxn14e2hxh19tyvpo' inline='true' source-platform='mac' version='9.3' xmlns:user='http://www.tableausoftware.com/xml/user'><connection authentication='sspi' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username=''></connection></datasource>'''
+
+TABLEAU_10_TDS = '''<?xml version='1.0' encoding='utf-8' ?><datasources><datasource caption='xy+ (Multiple Connections)' inline='true' name='federated.1s4nxn20cywkdv13ql0yk0g1mpdx' version='10.0'><connection class='federated'><named-connections><named-connection caption='mysql55.test.tsi.lan' name='mysql.1ewmkrw0mtgsev1dnurma1blii4x'><connection class='mysql' dbname='testv1' odbc-native-protocol='yes' port='3306' server='mysql55.test.tsi.lan' source-charset='' username='test' /></named-connection><named-connection caption='mssql2012.test.tsi.lan' name='sqlserver.1erdwp01uqynlb14ul78p0haai2r'><connection authentication='sqlserver' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username='test' /></named-connection></named-connections></connection></datasource></datasources>'''
 
 TABLEAU_10_WORKBOOK = '''<?xml version='1.0' encoding='utf-8' ?><workbook source-build='0.0.0 (0000.16.0510.1300)' source-platform='mac' version='10.0' xmlns:user='http://www.tableausoftware.com/xml/user'><datasources><datasource caption='xy+ (Multiple Connections)' inline='true' name='federated.1s4nxn20cywkdv13ql0yk0g1mpdx' version='10.0'><connection class='federated'><named-connections><named-connection caption='mysql55.test.tsi.lan' name='mysql.1ewmkrw0mtgsev1dnurma1blii4x'><connection class='mysql' dbname='testv1' odbc-native-protocol='yes' port='3306' server='mysql55.test.tsi.lan' source-charset='' username='test' /></named-connection><named-connection caption='mssql2012.test.tsi.lan' name='sqlserver.1erdwp01uqynlb14ul78p0haai2r'><connection authentication='sqlserver' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username='test' /></named-connection></named-connections></connection></datasource></datasources></workbook>'''
 
 TABLEAU_CONNECTION_XML = ET.fromstring(
     '''<connection authentication='sspi' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username=''></connection>''')
-
 
 class HelperMethodTests(unittest.TestCase):
 
@@ -39,13 +29,23 @@ class HelperMethodTests(unittest.TestCase):
         self.assertFalse(Workbook._is_valid_file('file1.tds2'))
         self.assertFalse(Workbook._is_valid_file('file2.twb3'))
 
+
 class ConnectionParserTests(unittest.TestCase):
 
     def test_can_extract_legacy_connection(self):
-        pass
+        parser = ConnectionParser(ET.fromstring(TABLEAU_93_TDS), '9.2')
+        connection = parser.get_connections()
+        self.assertIsInstance(connection, Connection)
+        self.assertEqual(connection.dbname, 'TestV1')
+
 
     def test_can_extract_federated_connections(self):
-        pass
+        parser = ConnectionParser(ET.fromstring(TABLEAU_10_TDS), '10.0')
+        connections = parser.get_connections()
+        self.assertIsInstance(connections, list)
+        self.assertIsInstance(connections[0], Connection)
+        self.assertEqual(connections[0].dbname, 'testv1')
+
 
 class ConnectionModelTests(unittest.TestCase):
 
@@ -122,33 +122,35 @@ class WorkbookModelTests(unittest.TestCase):
         new_wb = Workbook(self.workbook_file.name)
         self.assertEqual(new_wb.datasources[0].connection.dbname, 'newdb.test.tsi.lan')
 
-    def test_can_update_datasource_connection_and_saveV10(self):
-        temp = io.FileIO('v10test.twb', 'w')
-        temp.write(TABLEAU_10_WORKBOOK.encode())
-        temp.seek(0)
-        original_wb = Workbook(temp.name)
-        original_wb.datasources[0].connection[0].dbname = 'newdb.test.tsi.lan'
 
-        original_wb.save()
+class WorkbookModelV10Tests(unittest.TestCase):
 
-        new_wb = Workbook(temp.name)
-        self.assertEqual(new_wb.datasources[0].connection[0].dbname, 'newdb.test.tsi.lan')
+    def setUp(self):
+        self.workbook_file = io.FileIO('testv10.twb', 'w')
+        self.workbook_file.write(TABLEAU_10_WORKBOOK.encode('utf8'))
+        self.workbook_file.seek(0)
 
-        temp.close()
-        os.unlink(temp.name)
+    def tearDown(self):
+        self.workbook_file.close()
+        os.unlink(self.workbook_file.name)
 
     def test_can_extract_datasourceV10(self):
-        temp = io.FileIO('v10test.twb', 'w')
-        temp.write(TABLEAU_10_WORKBOOK.encode())
-        temp.seek(0)
-        wb = Workbook(temp.name)
+        wb = Workbook(self.workbook_file.name)
         self.assertEqual(len(wb.datasources), 1)
         self.assertEqual(len(wb.datasources[0].connection), 2)
         self.assertIsInstance(wb.datasources[0].connection, list)
         self.assertIsInstance(wb.datasources[0], Datasource)
         self.assertEqual(wb.datasources[0].name,
                          'federated.1s4nxn20cywkdv13ql0yk0g1mpdx')
-        temp.close()
+
+    def test_can_update_datasource_connection_and_saveV10(self):
+        original_wb = Workbook(self.workbook_file.name)
+        original_wb.datasources[0].connection[0].dbname = 'newdb.test.tsi.lan'
+
+        original_wb.save()
+
+        new_wb = Workbook(self.workbook_file.name)
+        self.assertEqual(new_wb.datasources[0].connection[0].dbname, 'newdb.test.tsi.lan')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
> Here is one approach I thought of to deal with v10 workbooks and legacy workbooks.
> 
> The idea is to hide all the connection parsing away from the Datasource class.
> 
> I have a few questions and would love a second opinion.
> 
> DO NOT MERGE THIS. Feedback only :)
> 
> Tests do pass, though ConnectionParser doesn't have any of its own yet.
> Added a v10 workbook to the tests. TODO: Cleanup the file handling

Addresses #5 

Subsumed by later comments
