### PR TITLE
Refactors suggested in last PR. 

### DIFF
--- a/Examples/Replicate Workbook/replicateWorkbook.py
+++ b/Examples/Replicate Workbook/replicateWorkbook.py
@@ -18,8 +18,8 @@ with open('databases.csv') as csvfile:
     databases = csv.DictReader(csvfile, delimiter=',', quotechar='"')
     for row in databases:
         # Set our unique values for this database
-        sourceWB.datasources[0].connection.server = row['Server']
-        sourceWB.datasources[0].connection.dbname = row['Database']
-        sourceWB.datasources[0].connection.username = row['User']
+        sourceWB.datasources[0].connections[0].server = row['Server']
+        sourceWB.datasources[0].connections[0].dbname = row['Database']
+        sourceWB.datasources[0].connections[0].username = row['User']
         # Save our newly created .twb with the new file name
         sourceWB.save_as(row['DBFriendlyName'] + ' - Superstore' + '.twb')

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We don't yet support creating files from scratch. In addition, support for `.twb
 
 
 ###Getting Started
-To use this SDK, you must have Python installed. You can use either 2.7x or 3.3x. 
+To use this SDK, you must have Python installed. You can use either 2.7.X or 3.3 and later.
 
 Download the `.zip` file that contains the SDK. Unzip the file and then run the following command:
 
@@ -24,7 +24,7 @@ Download the `.zip` file that contains the SDK. Unzip the file and then run the 
 pip install -e <directory containing setup.py>
 ```
 
-We plan on putting the package in PyPi to make installation easier. 
+We plan on putting the package in PyPi to make installation easier.
 
 
 ###Basics
@@ -35,23 +35,43 @@ from tableaudocumentapi import Workbook
 
 sourceWB = Workbook('WorkbookToUpdate.twb')
 
-sourceWB.datasources[0].connection.server = "MY-NEW-SERVER"
-sourceWB.datasources[0].connection.dbname = "NEW-DATABASE"
-sourceWB.datasources[0].connection.username = "benl"
+sourceWB.datasources[0].connections[0].server = "MY-NEW-SERVER"
+sourceWB.datasources[0].connections[0].dbname = "NEW-DATABASE"
+sourceWB.datasources[0].connections[0].username = "benl"
 
 sourceWB.save()
 ```
+
+With Data Integration in Tableau 10, a datasource can have multiple connections. To access the connections simply index them like you would datasources
+
+```python
+from tableaudocumentapi import Workbook
+
+sourceWB = Workbook('WorkbookToUpdate.twb')
+
+sourceWB.datasources[0].connections[0].server = "MY-NEW-SERVER"
+sourceWB.datasources[0].connections[0].dbname = "NEW-DATABASE"
+sourceWB.datasources[0].connections[0].username = "benl"
+
+sourceWB.datasources[0].connections[1].server = "MY-NEW-SERVER"
+sourceWB.datasources[0].connections[1].dbname = "NEW-DATABASE"
+sourceWB.datasources[0].connections[1].username = "benl"
+
+
+sourceWB.save()
+```
+
 
 **Notes**
 
 - Import the `Workbook` object from the `tableaudocumentapi` module.
 - To open a workbook, instantiate a `Workbook` object and pass the `.twb` file name in the constructor.
 - The `Workbook` object exposes a `datasources` collection.
-- Each datasource object has a `connection` object that supports a `server`, `dbname`, and `username` property. 
-- Save changes to the workbook by calling the `save` or `save_as` method.    
+- Each datasource object has a `connection` object that supports a `server`, `dbname`, and `username` property.
+- Save changes to the workbook by calling the `save` or `save_as` method.
 
 
 
 ###Examples
 
-The downloadable package contains an example named `replicateWorkbook.py` (in the folder `\Examples\Replicate Workbook`). This example reads an existing workbook and reads a .csv file that contains a list of servers, database names, and users. For each new user in the .csv file, the code copies the original workbook, updates the `server`, `dbname`, and `username` properties, and saves the workbook under a new name.  
+The downloadable package contains an example named `replicateWorkbook.py` (in the folder `\Examples\Replicate Workbook`). This example reads an existing workbook and reads a .csv file that contains a list of servers, database names, and users. For each new user in the .csv file, the code copies the original workbook, updates the `server`, `dbname`, and `username` properties, and saves the workbook under a new name.

--- a/tableaudocumentapi/datasource.py
+++ b/tableaudocumentapi/datasource.py
@@ -6,6 +6,7 @@
 import xml.etree.ElementTree as ET
 from tableaudocumentapi import Connection
 
+
 class ConnectionParser(object):
 
     def __init__(self, datasource_xml, version):
@@ -13,10 +14,10 @@ class ConnectionParser(object):
         self._dsversion = version
 
     def _extract_federated_connections(self):
-        return list(map(Connection,self._dsxml.findall('.//named-connections/named-connection/*')))
+        return list(map(Connection, self._dsxml.findall('.//named-connections/named-connection/*')))
 
     def _extract_legacy_connection(self):
-        return Connection(self._dsxml.find('connection'))
+        return list(map(Connection, self._dsxml.findall('connection')))
 
     def get_connections(self):
         if float(self._dsversion) < 10:
@@ -45,10 +46,12 @@ class Datasource(object):
         self._filename = filename
         self._datasourceXML = dsxml
         self._datasourceTree = ET.ElementTree(self._datasourceXML)
-        self._name = self._datasourceXML.get('name') or self._datasourceXML.get('formatted-name') # TDS files don't have a name attribute
+        self._name = self._datasourceXML.get('name') or self._datasourceXML.get(
+            'formatted-name')  # TDS files don't have a name attribute
         self._version = self._datasourceXML.get('version')
-        self._connection_parser = ConnectionParser(self._datasourceXML, version=self._version)
-        self._connection = self._connection_parser.get_connections()
+        self._connection_parser = ConnectionParser(
+            self._datasourceXML, version=self._version)
+        self._connections = self._connection_parser.get_connections()
 
     @classmethod
     def from_file(cls, filename):
@@ -84,7 +87,6 @@ class Datasource(object):
         """
         self._datasourceTree.write(new_filename)
 
-
     ###########
     # name
     ###########
@@ -103,5 +105,5 @@ class Datasource(object):
     # connection
     ###########
     @property
-    def connection(self):
-        return self._connection
+    def connections(self):
+        return self._connections

--- a/tableaudocumentapi/datasource.py
+++ b/tableaudocumentapi/datasource.py
@@ -102,7 +102,7 @@ class Datasource(object):
         return self._version
 
     ###########
-    # connection
+    # connections
     ###########
     @property
     def connections(self):

--- a/tableaudocumentapi/workbook.py
+++ b/tableaudocumentapi/workbook.py
@@ -92,7 +92,6 @@ class Workbook(object):
 
         self._workbookTree.write(new_filename)
 
-
     ###########################################################################
     #
     # Private API.
@@ -112,4 +111,3 @@ class Workbook(object):
     def _is_valid_file(filename):
         fileExtension = os.path.splitext(filename)[-1].lower()
         return fileExtension in ('.twb', '.tds')
-

--- a/test.py
+++ b/test.py
@@ -34,9 +34,10 @@ class ConnectionParserTests(unittest.TestCase):
 
     def test_can_extract_legacy_connection(self):
         parser = ConnectionParser(ET.fromstring(TABLEAU_93_TDS), '9.2')
-        connection = parser.get_connections()
-        self.assertIsInstance(connection, Connection)
-        self.assertEqual(connection.dbname, 'TestV1')
+        connections = parser.get_connections()
+        self.assertIsInstance(connections, list)
+        self.assertIsInstance(connections[0], Connection)
+        self.assertEqual(connections[0].dbname, 'TestV1')
 
 
     def test_can_extract_federated_connections(self):
@@ -85,15 +86,16 @@ class DatasourceModelTests(unittest.TestCase):
 
     def test_can_extract_connection(self):
         ds = Datasource.from_file(self.tds_file.name)
-        self.assertIsInstance(ds.connection, Connection)
+        self.assertIsInstance(ds.connections[0], Connection)
+        self.assertIsInstance(ds.connections, list)
 
     def test_can_save_tds(self):
         original_tds = Datasource.from_file(self.tds_file.name)
-        original_tds.connection.dbname = 'newdb.test.tsi.lan'
+        original_tds.connections[0].dbname = 'newdb.test.tsi.lan'
         original_tds.save()
 
         new_tds = Datasource.from_file(self.tds_file.name)
-        self.assertEqual(new_tds.connection.dbname, 'newdb.test.tsi.lan')
+        self.assertEqual(new_tds.connections[0].dbname, 'newdb.test.tsi.lan')
 
 
 class WorkbookModelTests(unittest.TestCase):
@@ -116,11 +118,11 @@ class WorkbookModelTests(unittest.TestCase):
 
     def test_can_update_datasource_connection_and_save(self):
         original_wb = Workbook(self.workbook_file.name)
-        original_wb.datasources[0].connection.dbname = 'newdb.test.tsi.lan'
+        original_wb.datasources[0].connections[0].dbname = 'newdb.test.tsi.lan'
         original_wb.save()
 
         new_wb = Workbook(self.workbook_file.name)
-        self.assertEqual(new_wb.datasources[0].connection.dbname, 'newdb.test.tsi.lan')
+        self.assertEqual(new_wb.datasources[0].connections[0].dbname, 'newdb.test.tsi.lan')
 
 
 class WorkbookModelV10Tests(unittest.TestCase):
@@ -137,20 +139,20 @@ class WorkbookModelV10Tests(unittest.TestCase):
     def test_can_extract_datasourceV10(self):
         wb = Workbook(self.workbook_file.name)
         self.assertEqual(len(wb.datasources), 1)
-        self.assertEqual(len(wb.datasources[0].connection), 2)
-        self.assertIsInstance(wb.datasources[0].connection, list)
+        self.assertEqual(len(wb.datasources[0].connections), 2)
+        self.assertIsInstance(wb.datasources[0].connections, list)
         self.assertIsInstance(wb.datasources[0], Datasource)
         self.assertEqual(wb.datasources[0].name,
                          'federated.1s4nxn20cywkdv13ql0yk0g1mpdx')
 
     def test_can_update_datasource_connection_and_saveV10(self):
         original_wb = Workbook(self.workbook_file.name)
-        original_wb.datasources[0].connection[0].dbname = 'newdb.test.tsi.lan'
+        original_wb.datasources[0].connections[0].dbname = 'newdb.test.tsi.lan'
 
         original_wb.save()
 
         new_wb = Workbook(self.workbook_file.name)
-        self.assertEqual(new_wb.datasources[0].connection[0].dbname, 'newdb.test.tsi.lan')
+        self.assertEqual(new_wb.datasources[0].connections[0].dbname, 'newdb.test.tsi.lan')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Now there is a connections property that always returns a list of connections. 

In the legacy case it's just a list of one, in the federated case it's all of them (in order they are in the twb). This gives folks a consistent API for the future.

Updated tests to match. Examples and README as well.

Tests pass on my Mac in Py2 and Py3