### PR TITLE
Basic Travis CI Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+#Other things
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "pypy"
+# command to install dependencies
+install:
+  - "pip install -e ."
+  - "pip install pep8"
+# command to run tests
+script:
+  # Tests
+  - python test.py
+  # pep8
+  - pep8 --ignore=E501 .
+  # Examples
+  - (cd "Examples/Replicate Workbook" && python replicateWorkbook.py)
+  - (cd "Examples/List TDS Info" && python listTDSInfo.py)
+

--- a/tableaudocumentapi/__init__.py
+++ b/tableaudocumentapi/__init__.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1'
-__VERSION__ = __version__
 from .connection import Connection
 from .datasource import Datasource, ConnectionParser
 from .workbook import Workbook
+__version__ = '0.0.1'
+__VERSION__ = __version__


### PR DESCRIPTION
Basic TravisCI yml file that tests the supported versions, runs PEP8 and runs the samples.

This doesn't have anything configured around branches or notification settings.

I also fixed a small pep8 violation in __init__.py and added .DS_STORE to the ignore file because my mac is evil