### PR TITLE
Data Source test updates and minor things

### DIFF
--- a/tableaudocumentapi/connection.py
+++ b/tableaudocumentapi/connection.py
@@ -26,6 +26,11 @@ class Connection(object):
         self._dbname = connxml.get('dbname')
         self._server = connxml.get('server')
         self._username = connxml.get('username')
+        self._authentication = connxml.get('authentication')
+        self._class = connxml.get('class')
+
+    def __repr__(self):
+        return "'<Connection server='{}' dbname='{}' @ {}>'".format(self._server, self._dbname, hex(id(self)))
 
     ###########
     # dbname
@@ -92,3 +97,17 @@ class Connection(object):
         """
         self._username = value
         self._connectionXML.set('username', value)
+
+    ###########
+    # authentication
+    ###########
+    @property
+    def authentication(self):
+        return self._authentication
+
+    ###########
+    # dbclass
+    ###########
+    @property
+    def dbclass(self):
+        return self._class

--- a/test.py
+++ b/test.py
@@ -10,7 +10,7 @@ TABLEAU_93_WORKBOOK = '''<?xml version='1.0' encoding='utf-8' ?><workbook source
 
 TABLEAU_93_TDS = '''<?xml version='1.0' encoding='utf-8' ?><datasource formatted-name='sqlserver.17u3bqc16tjtxn14e2hxh19tyvpo' inline='true' source-platform='mac' version='9.3' xmlns:user='http://www.tableausoftware.com/xml/user'><connection authentication='sspi' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username=''></connection></datasource>'''
 
-TABLEAU_10_TDS = '''<?xml version='1.0' encoding='utf-8' ?><datasources><datasource caption='xy+ (Multiple Connections)' inline='true' name='federated.1s4nxn20cywkdv13ql0yk0g1mpdx' version='10.0'><connection class='federated'><named-connections><named-connection caption='mysql55.test.tsi.lan' name='mysql.1ewmkrw0mtgsev1dnurma1blii4x'><connection class='mysql' dbname='testv1' odbc-native-protocol='yes' port='3306' server='mysql55.test.tsi.lan' source-charset='' username='test' /></named-connection><named-connection caption='mssql2012.test.tsi.lan' name='sqlserver.1erdwp01uqynlb14ul78p0haai2r'><connection authentication='sqlserver' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username='test' /></named-connection></named-connections></connection></datasource></datasources>'''
+TABLEAU_10_TDS = '''<?xml version='1.0' encoding='utf-8' ?><datasource caption='xy+ (Multiple Connections)' inline='true' name='federated.1s4nxn20cywkdv13ql0yk0g1mpdx' version='10.0'><connection class='federated'><named-connections><named-connection caption='mysql55.test.tsi.lan' name='mysql.1ewmkrw0mtgsev1dnurma1blii4x'><connection class='mysql' dbname='testv1' odbc-native-protocol='yes' port='3306' server='mysql55.test.tsi.lan' source-charset='' username='test' /></named-connection><named-connection caption='mssql2012.test.tsi.lan' name='sqlserver.1erdwp01uqynlb14ul78p0haai2r'><connection authentication='sqlserver' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username='test' /></named-connection></named-connections></connection></datasource>'''
 
 TABLEAU_10_WORKBOOK = '''<?xml version='1.0' encoding='utf-8' ?><workbook source-build='0.0.0 (0000.16.0510.1300)' source-platform='mac' version='10.0' xmlns:user='http://www.tableausoftware.com/xml/user'><datasources><datasource caption='xy+ (Multiple Connections)' inline='true' name='federated.1s4nxn20cywkdv13ql0yk0g1mpdx' version='10.0'><connection class='federated'><named-connections><named-connection caption='mysql55.test.tsi.lan' name='mysql.1ewmkrw0mtgsev1dnurma1blii4x'><connection class='mysql' dbname='testv1' odbc-native-protocol='yes' port='3306' server='mysql55.test.tsi.lan' source-charset='' username='test' /></named-connection><named-connection caption='mssql2012.test.tsi.lan' name='sqlserver.1erdwp01uqynlb14ul78p0haai2r'><connection authentication='sqlserver' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012.test.tsi.lan' username='test' /></named-connection></named-connections></connection></datasource></datasources></workbook>'''
 
@@ -58,13 +58,16 @@ class ConnectionModelTests(unittest.TestCase):
         self.assertEqual(conn.dbname, 'TestV1')
         self.assertEqual(conn.username, '')
         self.assertEqual(conn.server, 'mssql2012.test.tsi.lan')
+        self.assertEqual(conn.dbclass, 'sqlserver')
+        self.assertEqual(conn.authentication, 'sspi')
 
     def test_can_write_attributes_to_connection(self):
         conn = Connection(self.connection)
         conn.dbname = 'BubblesInMyDrink'
         conn.server = 'mssql2014.test.tsi.lan'
+        conn.username = 'bob'
         self.assertEqual(conn.dbname, 'BubblesInMyDrink')
-        self.assertEqual(conn.username, '')
+        self.assertEqual(conn.username, 'bob')
         self.assertEqual(conn.server, 'mssql2014.test.tsi.lan')
 
 
@@ -107,6 +110,36 @@ class DatasourceModelTests(unittest.TestCase):
             first_line = f.readline().strip()  # first line should be xml tag
             self.assertEqual(
                 first_line, "<?xml version='1.0' encoding='utf-8'?>")
+
+
+class DatasourceModelV10Tests(unittest.TestCase):
+
+    def setUp(self):
+        self.tds_file = io.FileIO('test10.tds', 'w')
+        self.tds_file.write(TABLEAU_10_TDS.encode('utf8'))
+        self.tds_file.seek(0)
+
+    def tearDown(self):
+        self.tds_file.close()
+        os.unlink(self.tds_file.name)
+
+    def test_can_extract_datasource_from_file(self):
+        ds = Datasource.from_file(self.tds_file.name)
+        self.assertEqual(ds.name, 'federated.1s4nxn20cywkdv13ql0yk0g1mpdx')
+        self.assertEqual(ds.version, '10.0')
+
+    def test_can_extract_connection(self):
+        ds = Datasource.from_file(self.tds_file.name)
+        self.assertIsInstance(ds.connections[0], Connection)
+        self.assertIsInstance(ds.connections, list)
+
+    def test_can_save_tds(self):
+        original_tds = Datasource.from_file(self.tds_file.name)
+        original_tds.connections[0].dbname = 'newdb.test.tsi.lan'
+        original_tds.save()
+
+        new_tds = Datasource.from_file(self.tds_file.name)
+        self.assertEqual(new_tds.connections[0].dbname, 'newdb.test.tsi.lan')
 
 
 class WorkbookModelTests(unittest.TestCase):


### PR DESCRIPTION
Replaces #12 in response to @LGraber 's feedback.

Per feedback dropping the search methods and just updating tests, the repr for debugging, and updating the connections model to expose a read only auth and dbclass. Fixed a small bug in that the v10 TDS was invalid XML.