### PR TITLE
Create New Connections per #68

### DIFF
--- a/tableaudocumentapi/connection.py
+++ b/tableaudocumentapi/connection.py
@@ -3,6 +3,7 @@
 # Connection - A class for writing connections to Tableau files
 #
 ###############################################################################
+import xml.etree.ElementTree as ET
 from tableaudocumentapi.dbclass import is_valid_dbclass
 
 
@@ -32,6 +33,18 @@ class Connection(object):
 
     def __repr__(self):
         return "'<Connection server='{}' dbname='{}' @ {}>'".format(self._server, self._dbname, hex(id(self)))
+
+    @classmethod
+    def from_attributes(cls, server, dbname, username, dbclass, authentication=''):
+        root = ET.Element('connection')
+        root.set('authentication', authentication)
+        xml = cls(root)
+        xml.server = server
+        xml.dbname = dbname
+        xml.username = username
+        xml.dbclass = dbclass
+
+        return xml
 
     ###########
     # dbname
@@ -120,4 +133,4 @@ class Connection(object):
             raise AttributeError("'{}' is not a valid database type".format(value))
 
         self._class = value
-        self._connectionXML.set('dbclass', value)
+        self._connectionXML.set('class', value)

--- a/tableaudocumentapi/connection.py
+++ b/tableaudocumentapi/connection.py
@@ -36,8 +36,7 @@ class Connection(object):
 
     @classmethod
     def from_attributes(cls, server, dbname, username, dbclass, authentication=''):
-        root = ET.Element('connection')
-        root.set('authentication', authentication)
+        root = ET.Element('connection', authentication=authentication)
         xml = cls(root)
         xml.server = server
         xml.dbname = dbname

--- a/tableaudocumentapi/datasource.py
+++ b/tableaudocumentapi/datasource.py
@@ -128,8 +128,8 @@ class Datasource(object):
         return cls(dsxml, filename)
 
     @classmethod
-    def from_scratch(cls, caption, connections):
-        root = ET.Element('datasource', caption=caption, version='10.0')
+    def from_connections(cls, caption, connections):
+        root = ET.Element('datasource', caption=caption, version='10.0', inline='true')
         outer_connection = ET.SubElement(root, 'connection')
         outer_connection.set('class', 'federated')
         named_conns = ET.SubElement(outer_connection, 'named-connections')
@@ -168,6 +168,7 @@ class Datasource(object):
             Nothing.
 
         """
+
         xfile._save_file(self._filename, self._datasourceTree, new_filename)
 
     ###########

--- a/tableaudocumentapi/datasource.py
+++ b/tableaudocumentapi/datasource.py
@@ -6,9 +6,9 @@
 import collections
 import itertools
 import random
-import string
 import xml.etree.ElementTree as ET
 import xml.sax.saxutils as sax
+from uuid import uuid4
 
 from tableaudocumentapi import Connection, xfile
 from tableaudocumentapi import Field
@@ -66,9 +66,30 @@ def _column_object_from_metadata_xml(metadata_xml):
     return _ColumnObjectReturnTuple(field_object.id, field_object)
 
 
+def base36encode(number):
+    """Converts an integer into a base36 string."""
+
+    ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+    base36 = ''
+    sign = ''
+
+    if number < 0:
+        sign = '-'
+        number = -number
+
+    if 0 <= number < len(ALPHABET):
+        return sign + ALPHABET[number]
+
+    while number != 0:
+        number, i = divmod(number, len(ALPHABET))
+        base36 = ALPHABET[i] + base36
+
+    return sign + base36
+
+
 def make_unique_name(dbclass):
-    rand_part = ''.join(random.choice(
-        string.ascii_lowercase + string.digits) for _ in range(28))
+    rand_part = base36encode(uuid4().int)
     name = dbclass + '.' + rand_part
     return name
 

--- a/tableaudocumentapi/xfile.py
+++ b/tableaudocumentapi/xfile.py
@@ -104,6 +104,10 @@ def save_into_archive(xml_tree, filename, new_filename=None):
 
 
 def _save_file(container_file, xml_tree, new_filename=None):
+
+    if container_file is None:
+        container_file = new_filename
+
     if zipfile.is_zipfile(container_file):
         save_into_archive(xml_tree, container_file, new_filename)
     else:

--- a/test/bvt.py
+++ b/test/bvt.py
@@ -74,6 +74,16 @@ class ConnectionModelTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             conn.dbclass = 'NotReal'
 
+    def test_can_create_connection_from_scratch(self):
+        conn = Connection.from_attributes(
+            server='a', dbname='b', username='c', dbclass='mysql', authentication='d')
+        self.assertEqual(conn.server, 'a')
+        self.assertEqual(conn.dbname, 'b')
+        self.assertEqual(conn.username, 'c')
+        self.assertEqual(conn.dbclass, 'mysql')
+        self.assertEqual(conn.authentication, 'd')
+
+
 
 class DatasourceModelTests(unittest.TestCase):
 

--- a/test/bvt.py
+++ b/test/bvt.py
@@ -83,12 +83,12 @@ class ConnectionModelTests(unittest.TestCase):
         self.assertEqual(conn.dbclass, 'mysql')
         self.assertEqual(conn.authentication, 'd')
 
-    def test_can_create_datasource_from_scratch(self):
+    def test_can_create_datasource_from_connections(self):
         conn1 = Connection.from_attributes(
             server='a', dbname='b', username='c', dbclass='mysql', authentication='d')
         conn2 = Connection.from_attributes(
             server='1', dbname='2', username='3', dbclass='mysql', authentication='7')
-        ds = Datasource.from_scratch('test', connections=[conn1, conn2])
+        ds = Datasource.from_connections('test', connections=[conn1, conn2])
 
         self.assertEqual(ds.connections[0].server, 'a')
         self.assertEqual(ds.connections[1].server, '1')

--- a/test/bvt.py
+++ b/test/bvt.py
@@ -84,7 +84,6 @@ class ConnectionModelTests(unittest.TestCase):
         self.assertEqual(conn.authentication, 'd')
 
 
-
 class DatasourceModelTests(unittest.TestCase):
 
     def setUp(self):

--- a/test/bvt.py
+++ b/test/bvt.py
@@ -83,6 +83,16 @@ class ConnectionModelTests(unittest.TestCase):
         self.assertEqual(conn.dbclass, 'mysql')
         self.assertEqual(conn.authentication, 'd')
 
+    def test_can_create_datasource_from_scratch(self):
+        conn1 = Connection.from_attributes(
+            server='a', dbname='b', username='c', dbclass='mysql', authentication='d')
+        conn2 = Connection.from_attributes(
+            server='1', dbname='2', username='3', dbclass='mysql', authentication='7')
+        ds = Datasource.from_scratch('test', connections=[conn1, conn2])
+
+        self.assertEqual(ds.connections[0].server, 'a')
+        self.assertEqual(ds.connections[1].server, '1')
+
 
 class DatasourceModelTests(unittest.TestCase):
 


### PR DESCRIPTION
This is all that we'd need for creating connections from scratch.

Authentication isn't validated right now so it's not very safe, it defaults to '' because I need to research more how this attribute works

Feedback:

- Name. The issue proposes .create() but our current pattern is from_something
- Approach -- though it's simple
- Thoughts on authentication
- Note I fixed a bug I introduced, the name of the dbclass in the xml is actually 'class'