### PR TITLE
Fix #87 by working around non-federated sqlproxy connections

### DIFF
--- a/tableaudocumentapi/datasource.py
+++ b/tableaudocumentapi/datasource.py
@@ -101,7 +101,9 @@ class ConnectionParser(object):
         self._dsversion = version
 
     def _extract_federated_connections(self):
-        return list(map(Connection, self._dsxml.findall('.//named-connections/named-connection/*')))
+        connections = list(map(Connection, self._dsxml.findall('.//named-connections/named-connection/*')))
+        connections.extend(map(Connection, self._dsxml.findall("./connection[@class='sqlproxy']")))
+        return connections
 
     def _extract_legacy_connection(self):
         return list(map(Connection, self._dsxml.findall('connection')))

--- a/test/assets/multiple_connections.twb
+++ b/test/assets/multiple_connections.twb
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- build main.16.0928.1300                                -->
+<workbook source-build='0.0.0 (0000.16.0928.1300)' source-platform='mac' version='10.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <datasources>
+    <datasource caption='xy (TestV1)' inline='true' name='sqlproxy.0uczajf02b02kv16u6atd08pslj5' version='10.1'>
+      <repository-location id='xyTestV1' path='/datasources' revision='1.0' />
+      <connection channel='http' class='sqlproxy' dbname='xyTestV1' directory='/dataserver' port='80' server='awesomeserver' username=''>
+        <relation name='sqlproxy' table='[sqlproxy]' type='table' />
+      </connection>
+    </datasource>
+    <datasource caption='xy+ (Multiple Connections)' inline='true' name='federated.1bw8gel1hkm5ms1c8jgrm0zixmde' version='10.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='mysql55' name='mysql.0unbi0i1tfh602155zoou04tacme'>
+            <connection class='mysql' dbname='testv1' odbc-native-protocol='' port='' server='mysql55' source-charset='' username='test' />
+          </named-connection>
+          <named-connection caption='mssql2012.test' name='sqlserver.15j0kvj16xdjas1bs191w1ji441w'>
+            <connection authentication='sqlserver' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012' username='test' />
+          </named-connection>
+        </named-connections>
+        <relation join='inner' type='join'>
+          <clause type='join'>
+            <expression op='='>
+              <expression op='[xy].[a]' />
+              <expression op='[xy1].[a]' />
+            </expression>
+          </clause>
+          <relation connection='mysql.0unbi0i1tfh602155zoou04tacme' name='xy' table='[xy]' type='table' />
+          <relation connection='sqlserver.15j0kvj16xdjas1bs191w1ji441w' name='xy1' table='[dbo].[xy]' type='table' />
+        </relation>
+      </connection>
+    </datasource>
+  </datasources>
+</workbook>

--- a/test/bvt.py
+++ b/test/bvt.py
@@ -27,6 +27,9 @@ TABLEAU_10_TDSX = os.path.join(TEST_DIR, 'assets', 'TABLEAU_10_TDSX.tdsx')
 
 EMPTY_WORKBOOK = os.path.join(TEST_DIR, 'assets', 'empty_workbook.twb')
 
+MULTI_CONNECTION_10 = os.path.join(
+    TEST_DIR, 'assets', 'multiple_connections.twb')
+
 
 class ConnectionParserTests(unittest.TestCase):
 
@@ -92,6 +95,26 @@ class ConnectionModelTests(unittest.TestCase):
 
         self.assertEqual(ds.connections[0].server, 'a')
         self.assertEqual(ds.connections[1].server, '1')
+
+
+class ConnectionParserInComplicatedWorkbooks(unittest.TestCase):
+
+    def setUp(self):
+        with open(MULTI_CONNECTION_10, 'rb') as in_file, open('test.twb', 'wb') as out_file:
+            out_file.write(in_file.read())
+            self.twb_file = out_file
+
+    def tearDown(self):
+        self.twb_file.close()
+        os.unlink(self.twb_file.name)
+
+    def test_can_mixed_connections_workbook(self):
+        wb = Workbook(self.twb_file.name)
+        self.assertTrue(len(wb.datasources), 2)
+        self.assertTrue(len(wb.datasources[1].connections), 2)
+        self.assertEqual(wb.datasources[0].connections[0].dbclass, 'sqlproxy')
+        self.assertEqual(wb.datasources[1].connections[0].dbclass, 'mysql')
+        self.assertEqual(wb.datasources[1].connections[1].dbclass, 'sqlserver')
 
 
 class DatasourceModelTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #87 

'sqlproxy' connections can't be federated yet so they exist outside the 'named-connections' groupings that all other connections live in.

The simplest change is to just grab all federated connections and then make a second pass to get the published datasource connections too.

Added a test to verify the case with a mixed-case workbook: Federated and Non-Federated connections