### PR TITLE
Removing unused imports per linter report

### DIFF
--- a/tableaudocumentapi/datasource.py
+++ b/tableaudocumentapi/datasource.py
@@ -5,7 +5,6 @@
 ###############################################################################
 import collections
 import itertools
-import random
 import xml.etree.ElementTree as ET
 import xml.sax.saxutils as sax
 from uuid import uuid4

--- a/tableaudocumentapi/workbook.py
+++ b/tableaudocumentapi/workbook.py
@@ -3,11 +3,8 @@
 # Workbook - A class for writing Tableau workbook files
 #
 ###############################################################################
-import os
-import zipfile
 import weakref
 
-import xml.etree.ElementTree as ET
 
 from tableaudocumentapi import Datasource, xfile
 from tableaudocumentapi.xfile import xml_open


### PR DESCRIPTION
Playing around with a new IDE and the linter noticed these weren't getting used anymore.