### PR TITLE
Issue #96: Add port support

### DIFF
--- a/tableaudocumentapi/connection.py
+++ b/tableaudocumentapi/connection.py
@@ -30,18 +30,20 @@ class Connection(object):
         self._username = connxml.get('username')
         self._authentication = connxml.get('authentication')
         self._class = connxml.get('class')
+        self.port = connxml.get('port', None)
 
     def __repr__(self):
         return "'<Connection server='{}' dbname='{}' @ {}>'".format(self._server, self._dbname, hex(id(self)))
 
     @classmethod
-    def from_attributes(cls, server, dbname, username, dbclass, authentication=''):
+    def from_attributes(cls, server, dbname, username, dbclass, port=None, authentication=''):
         root = ET.Element('connection', authentication=authentication)
         xml = cls(root)
         xml.server = server
         xml.dbname = dbname
         xml.username = username
         xml.dbclass = dbclass
+        xml.port = port
 
         return xml
 
@@ -133,3 +135,17 @@ class Connection(object):
 
         self._class = value
         self._connectionXML.set('class', value)
+
+    ###########
+    # port
+    ###########
+    @property
+    def port(self):
+        return self._port
+
+    @port.setter
+    def port(self, value):
+        self._port = value
+        # If port is None we don't actually want to update the XML
+        if value is not None:
+            self._connectionXML.set('port', value)

--- a/tableaudocumentapi/connection.py
+++ b/tableaudocumentapi/connection.py
@@ -30,7 +30,7 @@ class Connection(object):
         self._username = connxml.get('username')
         self._authentication = connxml.get('authentication')
         self._class = connxml.get('class')
-        self.port = connxml.get('port', None)
+        self._port = connxml.get('port', None)
 
     def __repr__(self):
         return "'<Connection server='{}' dbname='{}' @ {}>'".format(self._server, self._dbname, hex(id(self)))
@@ -146,6 +146,11 @@ class Connection(object):
     @port.setter
     def port(self, value):
         self._port = value
-        # If port is None we don't actually want to update the XML
-        if value is not None:
+        # If port is None we remove the element and don't write it to XML
+        if value is None:
+            try:
+                self._connectionXML.attrib.pop('port')
+            except KeyError:
+                pass
+        else:
             self._connectionXML.set('port', value)

--- a/tableaudocumentapi/connection.py
+++ b/tableaudocumentapi/connection.py
@@ -149,7 +149,7 @@ class Connection(object):
         # If port is None we remove the element and don't write it to XML
         if value is None:
             try:
-                self._connectionXML.attrib.pop('port')
+                del self._connectionXML.attrib['port']
             except KeyError:
                 pass
         else:

--- a/test/assets/CONNECTION.xml
+++ b/test/assets/CONNECTION.xml
@@ -1,1 +1,1 @@
-<connection authentication='sspi' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012' username=''></connection>
+<connection authentication='sspi' class='sqlserver' dbname='TestV1' odbc-native-protocol='yes' one-time-sql='' server='mssql2012' username='' port='1433'></connection>

--- a/test/bvt.py
+++ b/test/bvt.py
@@ -60,15 +60,18 @@ class ConnectionModelTests(unittest.TestCase):
         self.assertEqual(conn.server, 'mssql2012')
         self.assertEqual(conn.dbclass, 'sqlserver')
         self.assertEqual(conn.authentication, 'sspi')
+        self.assertEqual(conn.port, '1433')
 
     def test_can_write_attributes_to_connection(self):
         conn = Connection(self.connection)
         conn.dbname = 'BubblesInMyDrink'
         conn.server = 'mssql2014'
         conn.username = 'bob'
+        conn.port = '1337'
         self.assertEqual(conn.dbname, 'BubblesInMyDrink')
         self.assertEqual(conn.username, 'bob')
         self.assertEqual(conn.server, 'mssql2014')
+        self.assertEqual(conn.port, '1337')
 
     def test_bad_dbclass_rasies_attribute_error(self):
         conn = Connection(self.connection)
@@ -90,11 +93,13 @@ class ConnectionModelTests(unittest.TestCase):
         conn1 = Connection.from_attributes(
             server='a', dbname='b', username='c', dbclass='mysql', authentication='d')
         conn2 = Connection.from_attributes(
-            server='1', dbname='2', username='3', dbclass='mysql', authentication='7')
+            server='1', dbname='2', username='3', dbclass='mysql', port='1337', authentication='7')
         ds = Datasource.from_connections('test', connections=[conn1, conn2])
 
         self.assertEqual(ds.connections[0].server, 'a')
+        self.assertEqual(ds.connections[0].port, None)
         self.assertEqual(ds.connections[1].server, '1')
+        self.assertEqual(ds.connections[1].port, '1337')
 
 
 class ConnectionParserInComplicatedWorkbooks(unittest.TestCase):

--- a/test/bvt.py
+++ b/test/bvt.py
@@ -18,8 +18,7 @@ TABLEAU_10_TDS = os.path.join(TEST_DIR, 'assets', 'TABLEAU_10_TDS.tds')
 
 TABLEAU_10_TWB = os.path.join(TEST_DIR, 'assets', 'TABLEAU_10_TWB.twb')
 
-TABLEAU_CONNECTION_XML = ET.parse(os.path.join(
-    TEST_DIR, 'assets', 'CONNECTION.xml')).getroot()
+TABLEAU_CONNECTION_XML = os.path.join(TEST_DIR, 'assets', 'CONNECTION.xml')
 
 TABLEAU_10_TWBX = os.path.join(TEST_DIR, 'assets', 'TABLEAU_10_TWBX.twbx')
 
@@ -51,7 +50,7 @@ class ConnectionParserTests(unittest.TestCase):
 class ConnectionModelTests(unittest.TestCase):
 
     def setUp(self):
-        self.connection = TABLEAU_CONNECTION_XML
+        self.connection = ET.parse(TABLEAU_CONNECTION_XML).getroot()
 
     def test_can_read_attributes_from_connection(self):
         conn = Connection(self.connection)
@@ -72,6 +71,12 @@ class ConnectionModelTests(unittest.TestCase):
         self.assertEqual(conn.username, 'bob')
         self.assertEqual(conn.server, 'mssql2014')
         self.assertEqual(conn.port, '1337')
+
+    def test_can_delete_port_from_connection(self):
+        conn = Connection(self.connection)
+        conn.port = None
+        self.assertEqual(conn.port, None)
+        self.assertIsNone(conn._connectionXML.get('port'))
 
     def test_bad_dbclass_rasies_attribute_error(self):
         conn = Connection(self.connection)


### PR DESCRIPTION
Addresses #96 

Adding support for reading the `port` attribute from connections that have one.

We keep `None` in the model for cases where there is no port, but that won't get written to the XML.

Setting it to any other value will be persisted in the XML

This is a minimal change to resolve the issue -- I realize that we could do some cleanup on class construction like in the client-python-lib, but I don't think it's necessary in this PR