### PR TITLE
Added the ability to create and modify folders

### DIFF
--- a/tableaudocumentapi/datasource.py
+++ b/tableaudocumentapi/datasource.py
@@ -235,6 +235,56 @@ class Datasource(object):
             self._datasourceXML.remove(tag)
 
     ###########
+    # Folders
+    ###########
+
+    @property
+    def folders(self):
+        """ Returns all folders.
+        """
+        return self._datasourceTree.findall('.//folder')
+
+    def add_folder(self, name, role, fields):
+        """ Adds a folder field with the given fields.
+
+        Args:
+            name:  Name of the new folder. String.
+            role:  Role of the new folder. String.
+            fields:  Fields of the new folder. String.
+
+        Returns:
+            The new calculated folder that was created. ET.Element.
+        """
+        # TODO: It might be better to create a dedicated "Folder" object:
+        # Currently, there is a difference in Folder-Objects (ET.Elements) and
+        # other Fields (dedicated Field-objects)
+        folder = ET.Element('folder')
+        folder.set('name', name)
+        folder.set('role', role)
+
+        for field in fields:
+            item = ET.Element("folder-item")
+            item.set("name", field)
+            item.set("type", "field")
+            folder.append(item)
+
+        self._datasourceTree.getroot().append(folder)
+        return folder
+
+    def add_to_folder(self, name, fields):
+        """ Adds fields to a folder field with the given fields.
+        """
+        folder = self._datasourceTree.find(".//folder/[@name='{}']".format(name))
+        if not folder:
+            raise ValueError("Could not find a folder named {}.".format(name))
+
+        for field in fields:
+            item = ET.Element("folder-item")
+            item.set("name", field)
+            item.set("type", "field")
+            folder.append(item)
+
+    ###########
     # fields
     ###########
     @property

--- a/test/assets/folder_test.tds
+++ b/test/assets/folder_test.tds
@@ -1,0 +1,103 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- build 10000.16.0812.0001                               -->
+<datasource formatted-name='test_base' inline='true' source-platform='win' version='10.0' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <connection class='federated'>
+    <named-connections>
+      <named-connection caption='my.server.com' name='postgres.0slpt5u1crlvd816iez320cauqo3'>
+        <connection authentication='username-password' class='postgres' dbname='my_db' odbc-native-protocol='yes' port='5432' server='my.server.com' username='my_db_user' />
+      </named-connection>
+    </named-connections>
+    <relation connection='postgres.0slpt5u1crlvd816iez320cauqo3' name='my_data' table='[public].[my_data]' type='table' />
+    <metadata-records>
+      <metadata-record class='column'>
+        <remote-name>name</remote-name>
+        <remote-type>130</remote-type>
+        <local-name>[name]</local-name>
+        <parent-name>[my_data]</parent-name>
+        <remote-alias>name</remote-alias>
+        <ordinal>1</ordinal>
+        <local-type>string</local-type>
+        <aggregation>Count</aggregation>
+        <width>8190</width>
+        <contains-null>true</contains-null>
+        <cast-to-local-type>true</cast-to-local-type>
+        <collation flag='0' name='LEN_RUS' />
+        <attributes>
+          <attribute datatype='string' name='DebugRemoteType'>&quot;SQL_WLONGVARCHAR&quot;</attribute>
+          <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_WCHAR&quot;</attribute>
+        </attributes>
+      </metadata-record>
+      <metadata-record class='column'>
+        <remote-name>typ</remote-name>
+        <remote-type>130</remote-type>
+        <local-name>[typ]</local-name>
+        <parent-name>[my_data]</parent-name>
+        <remote-alias>typ</remote-alias>
+        <ordinal>2</ordinal>
+        <local-type>string</local-type>
+        <aggregation>Count</aggregation>
+        <width>8190</width>
+        <contains-null>true</contains-null>
+        <cast-to-local-type>true</cast-to-local-type>
+        <collation flag='0' name='LEN_RUS' />
+        <attributes>
+          <attribute datatype='string' name='DebugRemoteType'>&quot;SQL_WLONGVARCHAR&quot;</attribute>
+          <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_WCHAR&quot;</attribute>
+        </attributes>
+      </metadata-record>
+      <metadata-record class='column'>
+        <remote-name>amount</remote-name>
+        <remote-type>3</remote-type>
+        <local-name>[amount]</local-name>
+        <parent-name>[my_data]</parent-name>
+        <remote-alias>amount</remote-alias>
+        <ordinal>3</ordinal>
+        <local-type>integer</local-type>
+        <aggregation>Sum</aggregation>
+        <precision>10</precision>
+        <contains-null>true</contains-null>
+        <attributes>
+          <attribute datatype='string' name='DebugRemoteType'>&quot;SQL_INTEGER&quot;</attribute>
+          <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_SLONG&quot;</attribute>
+        </attributes>
+      </metadata-record>
+      <metadata-record class='column'>
+        <remote-name>price</remote-name>
+        <remote-type>5</remote-type>
+        <local-name>[price]</local-name>
+        <parent-name>[my_data]</parent-name>
+        <remote-alias>price</remote-alias>
+        <ordinal>4</ordinal>
+        <local-type>real</local-type>
+        <aggregation>Sum</aggregation>
+        <precision>17</precision>
+        <contains-null>true</contains-null>
+        <attributes>
+          <attribute datatype='string' name='DebugRemoteType'>&quot;SQL_FLOAT&quot;</attribute>
+          <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_DOUBLE&quot;</attribute>
+        </attributes>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <aliases enabled='yes' />
+  <column caption='Calculation One' datatype='integer' name='[Calculation_357754699576291328]' role='measure' type='quantitative'>
+    <calculation class='tableau' formula='[amount] * 100' />
+  </column>
+  <column datatype='integer' name='[Number of Records]' role='measure' type='quantitative' user:auto-column='numrec'>
+    <calculation class='tableau' formula='1' />
+  </column>
+  <column caption='The Amount' datatype='integer' name='[amount]' role='dimension' type='quantitative' />
+  <column caption='The Name' datatype='string' name='[name]' role='dimension' type='nominal' />
+  <column caption='The Price' datatype='real' name='[price]' role='measure' type='quantitative' />
+  <column caption='The Type' datatype='string' name='[typ]' role='dimension' type='nominal'>
+    <aliases>
+      <alias key='&quot;mein typ&quot;' value='mein typ alias jungeeeee' />
+    </aliases>
+  </column>
+  <layout dim-ordering='alphabetic' dim-percentage='0.48449' measure-ordering='alphabetic' measure-percentage='0.51551' show-aliased-fields='true' show-structure='true' />
+  <semantic-values>
+    <semantic-value key='[Country].[Name]' value='&quot;Germany&quot;' />
+  </semantic-values>
+  <date-options start-of-week='monday' />
+</datasource>

--- a/test/test_folders.py
+++ b/test/test_folders.py
@@ -1,0 +1,63 @@
+import unittest
+import os.path
+
+from tableaudocumentapi import Datasource
+import xml.etree.ElementTree as ET
+
+
+TEST_ASSET_DIR = os.path.join(
+    os.path.dirname(__file__),
+    'assets'
+)
+TEST_TDS_FILE = os.path.join(
+    TEST_ASSET_DIR,
+    'folder_test.tds'
+)
+
+
+class TestFieldChange(unittest.TestCase):
+
+    def setUp(self):
+        self.tds = Datasource.from_file(TEST_TDS_FILE)
+
+    def current_hash(self):
+        """ Return a hash of the current state of the XML.
+
+        Allows us to easily identify whether the underlying XML-structure
+        of a TDS-file has actually changed. Avoids false positives if,
+        for example, a fields value has changed but the XML hasn't.
+        """
+        return hash(ET.tostring(self.tds._datasourceTree.getroot()))
+
+    def test_folders(self):
+        """ Test if creating a folder works.
+        """
+        name = "MyTestFolder"
+        role = "dimensions"
+        fields = ["[name]", "[price]"]
+        fields2 = ["[typ]"]
+        state = self.current_hash()
+
+        self.tds.add_folder(name, role, fields)
+        # check hash
+        new_state = self.current_hash()
+        self.assertNotEqual(state, new_state)
+        state = new_state
+
+        self.tds.add_to_folder(name, fields2)
+        # check hash
+        new_state = self.current_hash()
+        self.assertNotEqual(state, new_state)
+
+    def test_folder_fail(self):
+        state = self.current_hash()
+
+        with self.assertRaises(ValueError):
+            self.tds.add_to_folder("not_existing_folder", [])
+        # check hash
+        new_state = self.current_hash()
+        self.assertEqual(state, new_state)
+        state = new_state
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_folders.py
+++ b/test/test_folders.py
@@ -29,35 +29,106 @@ class TestFieldChange(unittest.TestCase):
         """
         return hash(ET.tostring(self.tds._datasourceTree.getroot()))
 
-    def test_folders(self):
-        """ Test if creating a folder works.
+    @unittest.skip("Not yet implemented")
+    def test_get_existing_folders(self):
+        """ Test whether pre-existing folders in a TDS file are recognized.
+
+        The test-TDS-file already contains a folder named "testfolder"
+        This folder already contains a single field named "[price]"
         """
-        name = "MyTestFolder"
-        role = "dimensions"
-        fields = ["[name]", "[price]"]
-        fields2 = ["[typ]"]
+        folder = self.tds.folders["testfolder"]
+        self.assertIsNotNone(folder)
+        self.assertIn("[price]", folder.fields)
+
+    @unittest.skip("Not yet implemented")
+    def test_add_new_folder(self):
+        """ The test-TDS-file should allow new folders to be added.
+        """
+        folder_name = "another_testfolder"
         state = self.current_hash()
+        self.tds.add_folder(folder_name)
+        self.assertNotEqual(state, self.current_hash())
 
-        self.tds.add_folder(name, role, fields)
-        # check hash
-        new_state = self.current_hash()
-        self.assertNotEqual(state, new_state)
-        state = new_state
+        # the fields of this folder should be an empty dict
+        folder = self.tds.folders[folder_name]
+        self.assertIsNotNone(folder)
+        self.assertEqual(folder.fields, {})
 
-        self.tds.add_to_folder(name, fields2)
-        # check hash
-        new_state = self.current_hash()
-        self.assertNotEqual(state, new_state)
+    @unittest.skip("Not yet implemented")
+    def test_add_folder_duplicate(self):
+        """ The test-TDS-file should NOT allow duplicated folders to be added.
 
-    def test_folder_fail(self):
+        The test-TDS-file already contains a folder named "testfolder"
+        This folder already contains a single field named "[price]"
+        """
+        folder_name = "testfolder"
         state = self.current_hash()
+        with self.assertRaises(Exception):
+            self.tds.add_folder(folder_name)
+        self.assertEqual(state, self.current_hash())
 
-        with self.assertRaises(ValueError):
-            self.tds.add_to_folder("not_existing_folder", [])
-        # check hash
-        new_state = self.current_hash()
-        self.assertEqual(state, new_state)
-        state = new_state
+    @unittest.skip("Not yet implemented")
+    def test_add_to_folder(self):
+        """ A folder should be able to accept new fields.
+
+        The test-TDS-file already contains a folder named "testfolder"
+        This folder already contains a single field named "[price]"
+        """
+        new_field_name = "[amount]"
+        field = self.tds.fields[new_field_name]
+        self.assertIsNotNone(field)
+        folder = self.tds.folders["testfolder"]
+
+        # Test adding a field
+        state = self.current_hash()
+        folder.add_field(field)
+        # check whether object-representation has changed
+        self.assertIn(new_field_name, folder.fields)
+        # check whether xml-representation has changed
+        self.assertNotEqual(state, self.current_hash())
+
+    @unittest.skip("Not yet implemented")
+    def test_add_duplicate_to_folder(self):
+        """ A folder should disallow adding an already existing field.
+
+        The test-TDS-file already contains a folder named "testfolder"
+        This folder already contains a single field named "[price]"
+        """
+        new_field_name = "[price]"
+        field = self.tds.fields[new_field_name]
+        self.assertIsNotNone(field)
+        folder = self.tds.folders["testfolder"]
+
+        # check whether the field is already in the folder
+        self.assertIn(new_field_name, folder.fields)
+        # Test adding a field
+        state = self.current_hash()
+        with self.assertRaises(Exception):
+            folder.add_field(field)
+        # check whether xml-representation has not changed
+        self.assertEqual(state, self.current_hash())
+
+    @unittest.skip("Not yet implemented")
+    def test_remove_from_folder(self):
+        """ A folder should be able to delete fields from it.
+
+        The test-TDS-file already contains a folder named "testfolder"
+        This folder already contains a single field named "[price]"
+        """
+        # This field is already in the folder
+        field_name = "[price]"
+        field = self.tds.fields[field_name]
+        self.assertIsNotNone(field)
+        folder = self.tds.folders["testfolder"]
+        self.assertIn(field_name, folder)
+
+        # Test removing a field
+        state = self.current_hash()
+        folder.remove_field(field)
+        # check whether object-representation has changed
+        self.assertNotIn(field_name, folder.fields)
+        # check whether xml-representation has changed
+        self.assertNotEqual(state, self.current_hash())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #112 

Added the ability to:
* Query all existing folders
* Add folders
* Add fields to folders

Including tests.

TODO:
In the current revision, folders are treated as Elementtree.Element objects without any other wrapper around them. This means that folders currently differ from the other "fields" (aka <column .../>), which have their own wrapper object (field.py). 