### PR TITLE
Small cleanups for various editors. Play nice with built in test-runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,11 @@ target/
 .DS_Store
 .idea
 
+#Editor things
+*.sublime-project
+*.sublime-workspace
+settings.json
+tasks.json
+
 #Jekyll
 docs/_site

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,0 @@
-from . import bvt
-from . import test_datasource


### PR DESCRIPTION
1. Add Sublime and VSCode settings files to the gitignore
2. The __init__ in the test folder makes a lot of test runners angry because it imports some packages it doesn't need to. By removing that I can make some ides happier. This has no effect on `setup.py test`