### PR TITLE
#141 - Enabling Zip64 Extension to support zipfile >- 2GB.

### DIFF
--- a/tableaudocumentapi/xfile.py
+++ b/tableaudocumentapi/xfile.py
@@ -75,7 +75,7 @@ def find_file_in_zip(zip_file):
 
 
 def get_xml_from_archive(filename):
-    with zipfile.ZipFile(filename) as zf:
+    with zipfile.ZipFile(filename, allowZip64=True) as zf:
         with zf.open(find_file_in_zip(zf)) as xml_file:
             xml_tree = ET.parse(xml_file)
 
@@ -107,7 +107,7 @@ def save_into_archive(xml_tree, filename, new_filename=None):
 
     # Extract to temp directory
     with temporary_directory() as temp_path:
-        with zipfile.ZipFile(filename) as zf:
+        with zipfile.ZipFile(filename, allowZip64=True) as zf:
             xml_file = find_file_in_zip(zf)
             zf.extractall(temp_path)
         # Write the new version of the file to the temp directory
@@ -115,7 +115,7 @@ def save_into_archive(xml_tree, filename, new_filename=None):
             temp_path, xml_file), encoding="utf-8", xml_declaration=True)
 
         # Write the new archive with the contents of the temp folder
-        with zipfile.ZipFile(new_filename, "w", compression=zipfile.ZIP_DEFLATED) as new_archive:
+        with zipfile.ZipFile(new_filename, "w", compression=zipfile.ZIP_DEFLATED, allowZip64=True) as new_archive:
             build_archive_file(temp_path, new_archive)
 
 


### PR DESCRIPTION
[Tableau_CLA.pdf](https://github.com/tableau/document-api-python/files/1205837/Tableau_CLA.pdf)
