### PR TITLE
Fix #145

### DIFF
--- a/tableaudocumentapi/field.py
+++ b/tableaudocumentapi/field.py
@@ -65,7 +65,8 @@ class Field(object):
 
     def _initialize_from_metadata_xml(self, xmldata):
         for metadata_name, field_name in _METADATA_TO_FIELD_MAP:
-            self._apply_attribute(xmldata, field_name, lambda x: xmldata.find('.//{}'.format(metadata_name)).text,
+            self._apply_attribute(xmldata, field_name,
+                                  lambda x: getattr(xmldata.find('.//{}'.format(metadata_name)), 'text', None),
                                   read_name=metadata_name)
         self.apply_metadata(xmldata)
 

--- a/test/assets/datasource_test.tds
+++ b/test/assets/datasource_test.tds
@@ -71,6 +71,19 @@
           <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_SLONG&quot;</attribute>
         </attributes>
       </metadata-record>
+      <metadata-record class='column'>
+        <remote-name>z</remote-name>
+        <remote-type>1</remote-type>
+        <local-name>[z]</local-name>
+        <parent-name>[z]</parent-name>
+        <remote-alias>z</remote-alias>
+
+        <contains-null>true</contains-null>
+        <attributes>
+          <attribute datatype='string' name='DebugRemoteType'>&quot;SQL_INTEGER&quot;</attribute>
+          <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_SLONG&quot;</attribute>
+        </attributes>
+      </metadata-record>
     </metadata-records>
   </connection>
   <aliases enabled='yes' />


### PR DESCRIPTION
Update test TDS to have a field with no local-type and apply a default of None

Quick and dirty but it works and is scalable to any attribute we don't find.