### PR TITLE
Add None check for xml data

### DIFF
--- a/tableaudocumentapi/field.py
+++ b/tableaudocumentapi/field.py
@@ -62,8 +62,9 @@ class Field(object):
 
     def _initialize_from_metadata_xml(self, xmldata):
         for metadata_name, field_name in _METADATA_TO_FIELD_MAP:
-            self._apply_attribute(xmldata, field_name, lambda x: xmldata.find('.//{}'.format(metadata_name)).text,
-                                  read_name=metadata_name)
+            if(xmldata.find('.//{}'.format(metadata_name)) is not None):
+                self._apply_attribute(xmldata, field_name, lambda x: xmldata.find('.//{}'.format(metadata_name)).text,
+                                      read_name=metadata_name)
         self.apply_metadata(xmldata)
 
     ########################################


### PR DESCRIPTION
I ran into some issues while parsing bigger tableau files and received this error:

```
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/workbook.py", line 30, in __init__
    self._workbookRoot, self._datasource_index
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/workbook.py", line 115, in _prepare_worksheets
    if column_name in datasource.fields:
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/datasource.py", line 228, in fields
    self._fields = self._get_all_fields()
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/datasource.py", line 239, in _get_all_fields
    return FieldDictionary({k: v for k, v in field_objects})
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/datasource.py", line 239, in <dictcomp>
    return FieldDictionary({k: v for k, v in field_objects})
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/datasource.py", line 236, in <genexpr>
    metadata_only_field_objects = (x for x in self._get_metadata_objects() if x.id not in existing_column_fields)
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/datasource.py", line 243, in <genexpr>
    for x in self._datasourceTree.findall(".//metadata-record[@class='column']"))
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/datasource.py", line 59, in _column_object_from_metadata_xml
    field_object = Field.from_metadata_xml(metadata_xml)
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/field.py", line 86, in from_metadata_xml
    return cls(metadata_xml=xmldata)
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/field.py", line 54, in __init__
    self._initialize_from_metadata_xml(metadata_xml)
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/field.py", line 66, in _initialize_from_metadata_xml
    read_name=metadata_name)
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/field.py", line 94, in _apply_attribute
    value = default_func(attrib)
  File "/Users/kevin/.local/share/virtualenvs/tableaudiff-backend-gX1urzmf/lib/python3.7/site-packages/tableaudocumentapi/field.py", line 65, in <lambda>
    self._apply_attribute(xmldata, field_name, lambda x: xmldata.find('.//{}'.format(metadata_name)).text,
AttributeError: 'NoneType' object has no attribute 'text'
```

This PR adds a check for empty (`None`) and fixes the issue.