### PR TITLE
Adding legal and privacy links to footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -3,6 +3,7 @@
     <div class="row">
         <hr class="footer-hr">
         <p>This site is open source. Suggestions and pull requests are welcome on our <a href="https://github.com/tableau/document-api-python">GitHub page</a>.</p>
-        <p>&copy; Copyright <script>document.write(new Date().getFullYear())</script> Tableau</p>
+        <p><a href="https://www.tableau.com/en-us/legal" class="aLegal">LEGAL</a> <a href="https://www.tableau.com/en-us/privacy" class="aLegal">PRIVACY</a> &copy; 2003&ndash;<script>document.write(new Date().getFullYear())</script> TABLEAU SOFTWARE LLC. ALL RIGHTS RESERVED</p>
+        <sub>Documentation last generated on: {{ site.time }}</sub>
     </div>
 </footer>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -273,4 +273,8 @@ html {
 .size-1of2 { width: 50%; }
 .size-1of3 { width: 33.333%; }
 
-
+/* Legal and Privacy Links */
+.aLegal  {
+    word-spacing:  8px;
+    padding-right: 8px;
+}


### PR DESCRIPTION
@RussTheAerialist @jacalata 
Doc update:

- For GDPR compliance, adding links to the Tableau legal and privacy pages
- Updating styles and formatting to match other Tableau content

