### PR TITLE
 #162 preserve the xmlns:user namespace when saving a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+## 07 (26 May 2021)
+* Fix bug in xfile that overwrote the namespace name when saving a document
+
 ## 06 (11 January 2017)
 
 * Initial SQL and query banding support (#123)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name='tableaudocumentapi',
-    version='0.6',
+    version='0.7',
     author='Tableau',
     author_email='github@tableau.com',
     url='https://github.com/tableau/document-api-python',

--- a/tableaudocumentapi/xfile.py
+++ b/tableaudocumentapi/xfile.py
@@ -121,7 +121,7 @@ def save_into_archive(xml_tree, filename, new_filename=None):
 
 def _save_file(container_file, xml_tree, new_filename=None):
 
-    ET.register_namespace("user","http://www.tableausoftware.com/xml/user")
+    ET.register_namespace("user", "http://www.tableausoftware.com/xml/user")
     if new_filename is None:
         new_filename = container_file
 

--- a/tableaudocumentapi/xfile.py
+++ b/tableaudocumentapi/xfile.py
@@ -121,6 +121,7 @@ def save_into_archive(xml_tree, filename, new_filename=None):
 
 def _save_file(container_file, xml_tree, new_filename=None):
 
+    ET.register_namespace("user","http://www.tableausoftware.com/xml/user")
     if new_filename is None:
         new_filename = container_file
 


### PR DESCRIPTION
I wasn't able to connect to the sql datasource in the test files, but I was able to manually verify that the namespace was no longer changed in the xml. 
 #162 