### PR TITLE
Add Connection, NamedConnection and Relation classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/tableaudocumentapi/__init__.py
+++ b/tableaudocumentapi/__init__.py
@@ -1,7 +1,10 @@
+from .base import BaseObject
 from .field import Field
-from .connection import Connection
+from .relation import Relation
+from .connection import Connection, NamedConnection, RelationParser
 from .datasource import Datasource, ConnectionParser
 from .workbook import Workbook
+
 
 __version__ = '0.0.1'
 __VERSION__ = __version__

--- a/tableaudocumentapi/base.py
+++ b/tableaudocumentapi/base.py
@@ -1,0 +1,33 @@
+
+
+class BaseObject:
+
+    def _to_dict(
+        self, base_attrs=[], to_dict_attrs=[],
+        to_dict_list_attrs=[], to_dict_of_dict_attrs=[]
+    ):
+        base =  {
+            k.replace('_', ''): getattr(self, k) for k in base_attrs
+            if getattr(self, k)
+        }
+        base.update(
+            {
+                k: getattr(self, k).to_dict() for k in to_dict_attrs
+                if getattr(self, k)
+            }
+        )
+        base.update(
+            {
+                k: [i.to_dict() for i in getattr(self, k)]
+                for k in to_dict_list_attrs
+                if getattr(self, k)
+            }
+        )
+        base.update(
+            {
+                i: {k:v.to_dict() for k, v in getattr(self, i).items()}
+                for i in to_dict_of_dict_attrs
+                if getattr(self, i)
+            }
+        )
+        return base

--- a/tableaudocumentapi/connection.py
+++ b/tableaudocumentapi/connection.py
@@ -263,7 +263,7 @@ class Connection(BaseConnection):
         self._relation_parser = RelationParser(
             connxml, version=version
         )
-        self._relations = self._relation_parser.get_relations()
+        self._relation = self._relation_parser.get_relations()
 
     def _extract_named_connections(self):
         named_connections = [
@@ -276,12 +276,12 @@ class Connection(BaseConnection):
         return self._named_connections
 
     @property
-    def relations(self):
-        return self._relations
+    def relation(self):
+        return self._relation
 
     def to_dict(self):
         base = super().base_dict()
-        to_dict_list_attrs = ['relations']
+        to_dict_list_attrs = ['relation']
         to_dict_of_dict_attrs = ['named_connections']
         base.update(
             self._to_dict(

--- a/tableaudocumentapi/relation.py
+++ b/tableaudocumentapi/relation.py
@@ -1,0 +1,138 @@
+from tableaudocumentapi import BaseObject
+
+
+class Expression(BaseObject):
+
+    def __init__(self, expxml):
+        self._expressionXML = expxml
+        self._op = expxml.get('op')
+        self._expressions = self._extract_expressions() or None
+
+    def _extract_expressions(self):
+        return list(map(Expression, self._expressionXML.findall('./expression')))
+
+    @property
+    def op(self):
+        return self._op
+
+    @property
+    def expressions(self):
+        return self._expressions
+
+    def to_dict(self):
+        base = {
+            'op': self.op
+        }
+        if self.expressions:
+            base['expressions'] = [exp.to_dict() for exp in self.expressions]
+        return base
+
+
+class Clause(BaseObject):
+
+    def __init__(self, clxml):
+        self._clauseXML = clxml
+        self._type = clxml.get('type')
+        self._expression = self._extract_expression()
+
+    def _extract_expression(self):
+        expxml = self._clauseXML.find('./expression')
+        if expxml is not None:
+            return Expression(expxml)
+        else:
+            return None
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def expression(self):
+        return self._expression
+
+    def to_dict(self):
+        return {
+            'type': self.type,
+            'expression': self.expression.to_dict()
+        }
+
+
+class Relation(BaseObject):
+    """A class representing relations inside Connections."""
+
+    def __init__(self, relxml):
+        self._relationXML = relxml
+        self._type = relxml.get('type')
+        self._connection = relxml.get('connection')
+        self._name = relxml.get('name')
+        self._table = relxml.get('table')
+        self._text = self._extract_text()
+        self._clause = self._extract_clause()
+        self._relations = self._extract_relations()
+
+    def _extract_clause(self):
+        clxml = self._relationXML.find('./clause')
+        if clxml is not None:
+            return Clause(clxml)
+        else:
+            return None
+
+    def _extract_relations(self):
+        relxmls = self._relationXML.findall('./relation')
+        if relxmls:
+            return list(map(Relation, relxmls))
+        else:
+            return None
+
+    def _extract_text(self):
+        text = None
+        if self._relationXML.text:
+            if not self._relationXML.text.isspace():
+                text = self._relationXML.text
+        return text
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def connection(self):
+        return self._connection
+
+    @property
+    def table(self):
+        return self._table
+
+    @property
+    def text(self):
+        return self._text
+
+    @property
+    def clause(self):
+        return self._clause
+
+    @property
+    def relation(self):
+        return self._relations
+
+    def _base_dict(self):
+        base_attrs = ['type', 'name', 'connection', 'table', 'text']
+        return self._to_dict(
+            base_attrs=base_attrs
+        )
+
+    def to_dict(self):
+        to_dict_attrs = ['clause']
+        to_dict_list_attrs = ['relation']
+        base = self._base_dict()
+        base.update(
+            self._to_dict(
+                to_dict_attrs=to_dict_attrs,
+                to_dict_list_attrs=to_dict_list_attrs,
+            )
+        )
+        return base

--- a/tableaudocumentapi/relation.py
+++ b/tableaudocumentapi/relation.py
@@ -68,7 +68,7 @@ class Relation(BaseObject):
         self._table = relxml.get('table')
         self._text = self._extract_text()
         self._clause = self._extract_clause()
-        self._relations = self._extract_relations()
+        self._relation = self._extract_relations()
 
     def _extract_clause(self):
         clxml = self._relationXML.find('./clause')
@@ -117,7 +117,7 @@ class Relation(BaseObject):
 
     @property
     def relation(self):
-        return self._relations
+        return self._relation
 
     def _base_dict(self):
         base_attrs = ['type', 'name', 'connection', 'table', 'text']


### PR DESCRIPTION
New Connection, NamedConnection and Relation classes, added to support extraction of metadata via [tap-tableau-server](https://github.com/tailsdotcom/tap-tableau-server). From the readme:

> tap-tableau-server is a Singer tap for Tableau Server, focused (currently) on extracting details embedded inside Workbook files. This includes Datasources, Connections and Relations, as well as retrieving table references from embedded Custom SQL text fields inside Relation entities.
>
> Extracting the specifics of Datasources, Connections, Relations and Table References from each Workbook help answer questions like:
>
> - Which Workbooks depend on which tables in which databases?
> - How many Workbooks depend on Excel, CSV or Google Sheets?
> - Who's credentials are used for embedded connections, in which Workbooks?
>
> Having answers to all of these questions has helped us with wrangling our Tableau Server instance, which is several years old and has over 1000 Workbooks.
>
> In future, we hope to extend this tap to cover other metadata that is exposed by the Tableau Server API's directly (esp. Published Connections and child objects). PR submission very welcome. Watch this space!
