### PR TITLE
Remove extra print statement recently added for debugging

### DIFF
--- a/samples/preserve-namespaces/preserve-namespaces.py
+++ b/samples/preserve-namespaces/preserve-namespaces.py
@@ -16,7 +16,7 @@ def assertContainsUserNamespace(filename):
             lineCount += 1
     found = doc_beginning_excerpt.rfind("xmlns:user=")
     print(doc_beginning_excerpt[found:found+10])
-    assert(found >= 0)
+    assert (found >= 0)
 
 
 ############################################################

--- a/tableaudocumentapi/field.py
+++ b/tableaudocumentapi/field.py
@@ -70,7 +70,6 @@ class Field(object):
             self._apply_attribute(xmldata, field_name,
                                   lambda x: getattr(xmldata.find('.//{}'.format(metadata_name)), 'text', None),
                                   read_name=metadata_name)
-            print(metadata_name, field_name)
         self.apply_metadata(xmldata)
 
     @classmethod


### PR DESCRIPTION
This was (accidentally?) added as part of this recent big change:
https://github.com/tableau/document-api-python/pull/231/files#diff-e809266bfca3de00b55fcdb4ad03ddcf3390342af6709d9af442b4008c2e99fdR73