### PR TITLE
Remove distutils dependency (Python 3.12+); fix API-reference drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo contains Python source and example files for the Tableau Document API.
 The Document API provides a useful but *unsupported* way to programmatically make updates to Tableau workbook and data source files. If you've been making changes to these file types by directly updating the XML--that is, by XML hacking--this SDK is for you :) Get help from other users on the [Tableau Community Forums](https://community.tableau.com/s/topic/0TO4T000000SF3sWAG/document-api).
 
 Features include:
-- Support for TWB, TWBX, TDE and TDSX files starting roughly back to Tableau 9.x
+- Support for TWB, TWBX, TDS and TDSX files starting roughly back to Tableau 9.x
 - Getting connection information from data sources and workbooks
   - Server Name
   - Username

--- a/docs/docs/api-ref.md
+++ b/docs/docs/api-ref.md
@@ -28,7 +28,7 @@ The Workbook class represents a tableau workbook. It may be either a TWB or TWBX
 Saves any changes to the workbook to the existing file.
 
 `Workbook.save_as(self, new_filename):`
-Saves any changes to the workbook to a new file specified by the `new_file` parameter.
+Saves any changes to the workbook to a new file specified by the `new_filename` parameter.
 
 **Properties:**
 
@@ -117,7 +117,7 @@ Represents a field in a datasource
 **Raises:**
 
 **Methods:**
-`Field.create_field_xml()` Create field from scratch.
+`Field.create_field_xml(caption, datatype, hidden, role, field_type, name)` Create field from scratch.
 
 `Field.add_alias(self, key, value)` Add an alias for a given display value.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ The Document API provides an *unsupported* way to programmatically make updates 
 
 Features include:
 
-- Support for TWB, TWBX, TDE and TDSX files starting roughly back to Tableau 9.x
+- Support for TWB, TWBX, TDS and TDSX files starting roughly back to Tableau 9.x
 - Getting connection information from data sources and workbooks
     - Server Name
     - Username

--- a/tableaudocumentapi/xfile.py
+++ b/tableaudocumentapi/xfile.py
@@ -5,9 +5,20 @@ import tempfile
 import zipfile
 from lxml import etree as ET
 
-from distutils.version import LooseVersion as Version
 
-MIN_SUPPORTED_VERSION = Version("9.0")
+def _parse_version(version_string):
+    """Parse a dotted Tableau file version (e.g. '9.0', '18.1') into a
+    comparable tuple, treating any non-numeric segment as 0."""
+    parts = []
+    for part in version_string.split('.'):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+MIN_SUPPORTED_VERSION = _parse_version("9.0")
 
 
 class TableauVersionNotSupportedException(Exception):
@@ -31,9 +42,9 @@ def xml_open(filename, expected_root=None):
 
     # Is the file a supported version
     tree_root = tree.getroot()
-    file_version = Version(tree_root.attrib.get('version', '0.0'))
+    file_version = tree_root.attrib.get('version', '0.0')
 
-    if file_version < MIN_SUPPORTED_VERSION:
+    if _parse_version(file_version) < MIN_SUPPORTED_VERSION:
         raise TableauVersionNotSupportedException(file_version)
 
     # Does the root tag match the object type (workbook or data source)


### PR DESCRIPTION
Two commits:

1. **Remove the `distutils` dependency** — `tableaudocumentapi/xfile.py` imported `LooseVersion` from `distutils`, which was removed from the standard library in Python 3.12; on a clean install (without setuptools present to shim `distutils`) the package fails at import. Tableau file versions are simple dotted numerics, so they're now parsed into comparable tuples by a small local helper, with no new dependency. The unsupported-version exception now carries the raw version string.
2. **Docs drift** — `docs/docs/api-ref.md` described `save_as`'s parameter as `new_file` (it's `new_filename`, per `workbook.py`) and showed `Field.create_field_xml()` with no arguments (it requires six positional arguments, per `field.py`); the README and docs index claimed TDE support, but nothing in the package reads TDE — `find_file_in_zip` only extracts `twb`/`tds` entries — so the supported list now reads TWB/TWBX/TDS/TDSX.

**Verification:** full `python -m unittest discover` passes locally (52 tests OK; Python 3.14, macOS arm64), and the package imports cleanly in a fresh venv with only `lxml` installed (which fails on `master`).

Prepared with AI assistance (Claude); each claim verified against the source as described.